### PR TITLE
Change `lang` default to `undefined` + update tests + update util

### DIFF
--- a/lib/commands/addon.js
+++ b/lib/commands/addon.js
@@ -18,7 +18,6 @@ module.exports = NewCommand.extend({
     {
       name: 'lang',
       type: String,
-      default: '',
       description: 'Sets the base human language of the application via index.html',
       aliases: ['l'],
     },

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -33,7 +33,6 @@ module.exports = Command.extend({
     {
       name: 'lang',
       type: String,
-      default: '',
       description: 'Sets the base human language of the application via index.html',
       aliases: ['l'],
     },

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -33,7 +33,6 @@ module.exports = Command.extend({
     {
       name: 'lang',
       type: String,
-      default: '',
       description: 'Sets the base human language of the application via index.html',
       aliases: ['l'],
     },

--- a/lib/utilities/valid-lang-flag.js
+++ b/lib/utilities/valid-lang-flag.js
@@ -97,7 +97,7 @@ const PROG_LANGS = [
 ];
 
 function isProgLang(langArg) {
-  return PROG_LANGS.includes(langArg.toLowerCase().trim());
+  return langArg && PROG_LANGS.includes(langArg.toLowerCase().trim());
 }
 
 function getProgLangMsg(langArg) {
@@ -112,7 +112,7 @@ function getProgLangMsg(langArg) {
 // It gets rejected as a valid language code, but the option doesn't get
 // executed as intended.
 function isCliOption(langArg) {
-  return langArg[0] === '-';
+  return langArg && langArg[0] === '-';
 }
 
 function getCliMsg(langArg) {

--- a/tests/fixtures/help/help-with-addon.txt
+++ b/tests/fixtures/help/help-with-addon.txt
@@ -19,7 +19,7 @@ ember addon \u001b[33m<addon-name>\u001b[39m \u001b[36m<options...>\u001b[39m
   \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m
   \u001b[36m--directory\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -dir <value>\u001b[39m
-  \u001b[36m--lang\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: "")\u001b[39m Sets the base human language of the application via index.html
+  \u001b[36m--lang\u001b[39m \u001b[36m(String)\u001b[39m Sets the base human language of the application via index.html
     \u001b[90maliases: -l <value>\u001b[39m
 
 ember asset-sizes \u001b[36m<options...>\u001b[39m
@@ -97,7 +97,7 @@ ember init \u001b[33m<glob-pattern>\u001b[39m \u001b[36m<options...>\u001b[39m
   \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m
   \u001b[36m--name\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: "")\u001b[39m
     \u001b[90maliases: -n <value>\u001b[39m
-  \u001b[36m--lang\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: "")\u001b[39m Sets the base human language of the application via index.html
+  \u001b[36m--lang\u001b[39m \u001b[36m(String)\u001b[39m Sets the base human language of the application via index.html
     \u001b[90maliases: -l <value>\u001b[39m
 
 ember install \u001b[33m<addon-name>\u001b[39m \u001b[36m<options...>\u001b[39m
@@ -129,7 +129,7 @@ ember new \u001b[33m<app-name>\u001b[39m \u001b[36m<options...>\u001b[39m
   \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m
   \u001b[36m--directory\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -dir <value>\u001b[39m
-  \u001b[36m--lang\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: "")\u001b[39m Sets the base human language of the application via index.html
+  \u001b[36m--lang\u001b[39m \u001b[36m(String)\u001b[39m Sets the base human language of the application via index.html
     \u001b[90maliases: -l <value>\u001b[39m
 
 ember serve \u001b[36m<options...>\u001b[39m

--- a/tests/fixtures/help/help.js
+++ b/tests/fixtures/help/help.js
@@ -73,7 +73,6 @@ module.exports = {
         {
           name: 'lang',
           key: 'lang',
-          default: '',
           description: 'Sets the base human language of the application via index.html',
           aliases: ['l'],
           required: false
@@ -427,7 +426,6 @@ module.exports = {
         {
           name: 'lang',
           key: 'lang',
-          default: '',
           description: 'Sets the base human language of the application via index.html',
           aliases: ['l'],
           required: false
@@ -540,7 +538,6 @@ module.exports = {
         {
           name: 'lang',
           key: 'lang',
-          default: '',
           description: 'Sets the base human language of the application via index.html',
           aliases: ['l'],
           required: false

--- a/tests/fixtures/help/help.txt
+++ b/tests/fixtures/help/help.txt
@@ -19,7 +19,7 @@ ember addon \u001b[33m<addon-name>\u001b[39m \u001b[36m<options...>\u001b[39m
   \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m
   \u001b[36m--directory\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -dir <value>\u001b[39m
-  \u001b[36m--lang\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: "")\u001b[39m Sets the base human language of the application via index.html
+  \u001b[36m--lang\u001b[39m \u001b[36m(String)\u001b[39m Sets the base human language of the application via index.html
     \u001b[90maliases: -l <value>\u001b[39m
 
 ember asset-sizes \u001b[36m<options...>\u001b[39m
@@ -97,7 +97,7 @@ ember init \u001b[33m<glob-pattern>\u001b[39m \u001b[36m<options...>\u001b[39m
   \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m
   \u001b[36m--name\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: "")\u001b[39m
     \u001b[90maliases: -n <value>\u001b[39m
-  \u001b[36m--lang\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: "")\u001b[39m Sets the base human language of the application via index.html
+  \u001b[36m--lang\u001b[39m \u001b[36m(String)\u001b[39m Sets the base human language of the application via index.html
     \u001b[90maliases: -l <value>\u001b[39m
 
 ember install \u001b[33m<addon-name>\u001b[39m \u001b[36m<options...>\u001b[39m
@@ -129,7 +129,7 @@ ember new \u001b[33m<app-name>\u001b[39m \u001b[36m<options...>\u001b[39m
   \u001b[36m--yarn\u001b[39m \u001b[36m(Boolean)\u001b[39m
   \u001b[36m--directory\u001b[39m \u001b[36m(String)\u001b[39m
     \u001b[90maliases: -dir <value>\u001b[39m
-  \u001b[36m--lang\u001b[39m \u001b[36m(String)\u001b[39m \u001b[36m(Default: "")\u001b[39m Sets the base human language of the application via index.html
+  \u001b[36m--lang\u001b[39m \u001b[36m(String)\u001b[39m Sets the base human language of the application via index.html
     \u001b[90maliases: -l <value>\u001b[39m
 
 ember serve \u001b[36m<options...>\u001b[39m

--- a/tests/fixtures/help/with-addon-blueprints.js
+++ b/tests/fixtures/help/with-addon-blueprints.js
@@ -73,7 +73,6 @@ module.exports = {
         {
           name: 'lang',
           key: 'lang',
-          default: '',
           description: 'Sets the base human language of the application via index.html',
           aliases: ['l'],
           required: false
@@ -459,7 +458,6 @@ module.exports = {
         {
           name: 'lang',
           key: 'lang',
-          default: '',
           description: 'Sets the base human language of the application via index.html',
           aliases: ['l'],
           required: false
@@ -572,7 +570,6 @@ module.exports = {
         {
           name: 'lang',
           key: 'lang',
-          default: '',
           description: 'Sets the base human language of the application via index.html',
           aliases: ['l'],
           required: false

--- a/tests/fixtures/help/with-addon-commands.js
+++ b/tests/fixtures/help/with-addon-commands.js
@@ -73,7 +73,6 @@ module.exports = {
         {
           name: 'lang',
           key: 'lang',
-          default: '',
           description: 'Sets the base human language of the application via index.html',
           aliases: ['l'],
           required: false
@@ -427,7 +426,6 @@ module.exports = {
         {
           name: 'lang',
           key: 'lang',
-          default: '',
           description: 'Sets the base human language of the application via index.html',
           aliases: ['l'],
           required: false
@@ -540,7 +538,6 @@ module.exports = {
         {
           name: 'lang',
           key: 'lang',
-          default: '',
           description: 'Sets the base human language of the application via index.html',
           aliases: ['l'],
           required: false

--- a/tests/unit/commands/init-test.js
+++ b/tests/unit/commands/init-test.js
@@ -231,11 +231,10 @@ describe('init command', function () {
   // ember init --lang flag
   // -------------------------------
   // Good: Default
-  it('ember init without --lang flag (default) has no error message before run; blueprint has lang key of empty String', async function () {
+  it('ember init without --lang flag (default) has no error message before run; blueprint does not have lang key', async function () {
     tasks.InstallBlueprint = Task.extend({
       run(blueprintOpts) {
-        expect(blueprintOpts).to.contain.keys('lang');
-        expect(blueprintOpts.lang).to.equal('');
+        expect(blueprintOpts).to.not.contain.keys('lang');
         return Promise.reject('Called run');
       },
     });

--- a/tests/unit/commands/new-test.js
+++ b/tests/unit/commands/new-test.js
@@ -110,7 +110,7 @@ describe('new command', function () {
   // ember new --lang flag
   // -------------------------------
   // Good: Default
-  it('ember new without --lang flag (default) has no error message before run; blueprint has lang key of empty String', async function () {
+  it('ember new without --lang flag (default) has no error message before run; blueprint does not have lang key', async function () {
     command.tasks.CreateAndStepIntoDirectory = Task.extend({
       run() {
         return Promise.resolve();
@@ -119,7 +119,7 @@ describe('new command', function () {
     command.commands.Init = Command.extend({
       run(commandOptions) {
         expect(commandOptions).to.contain.keys('lang');
-        expect(commandOptions.lang).to.equal('');
+        expect(commandOptions.lang).to.equal(undefined);
         return Promise.resolve('Called run');
       },
     });


### PR DESCRIPTION
- Remove the empty String default for `availableOptions` in `new`, `init`, and `addon`  commands (i.e., change to `undefined`)

- Add checks to lang utility: assert that the input passed exists before attempting to format it or evaluate whether or not it is a valid language code, etc.

- Update relevant unit test logic

- Update test fixtures and `help`-related items accordingly